### PR TITLE
CloudFront behavious and Construct conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# Aligent AWS Static Hosting Stack
+# Aligent AWS Static Hosting
 
 ## Overview
 
-This repository defines a CDK stack for hosting a static website on AWS using S3 and CloudFront. 
+This repository defines a CDK construct for hosting a static website on AWS using S3 and CloudFront. 
 It can be imported and use within CDK application.
 
 ## Example
-The following CDK snippet can be used to provision the static hosting stack.
+The following CDK snippet can be used to provision a static hosting stack using this construct.
 
 ```
 import 'source-map-support/register';
 import * as cdk from '@aws-cdk/core';
-import { StaticHostingStack } from '@aligent/aws-cdk-static-hosting-stack'
-import { Construct } from '@aws-cdk/core';
+import { StaticHosting } from '@aligent/aws-cdk-static-hosting'
+import { Stack } from '@aws-cdk/core';
 
 const hostingStackProps = {
      env: {
@@ -28,7 +28,11 @@ const hostingStackProps = {
      createPublisherUser: true,
 };
 
-const app = new cdk.App();
+class StaticHostingStack extends Stack {
+  constructor(scope: Construct, id: string, props: hostingStackProps) {
+    super(scope, id, props);
 
-new StaticHostingStack(scope, 'PWA-hosting-stack', hostingStackProps);
+    new StaticHosting(scope, 'PWA-hosting-stack', props);
+  }
+}
 ```

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,3 @@
-import { StaticHostingStack } from "./lib/static-hosting-stack"
+import { StaticHosting } from "./lib/static-hosting"
 
-export { StaticHostingStack };
+export { StaticHosting };

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,3 @@
-import { StaticHosting } from "./lib/static-hosting"
+import { StaticHosting, StaticHostingProps } from "./lib/static-hosting"
 
-export { StaticHosting };
+export { StaticHosting, StaticHostingProps };

--- a/lib/static-hosting.ts
+++ b/lib/static-hosting.ts
@@ -1,11 +1,11 @@
 import { Construct, CfnOutput, RemovalPolicy, StackProps, Stack} from '@aws-cdk/core';
 import { Bucket, BucketEncryption, BlockPublicAccess } from '@aws-cdk/aws-s3';
-import { OriginAccessIdentity, CloudFrontWebDistribution, PriceClass, ViewerProtocolPolicy, SecurityPolicyProtocol, SSLMethod, Behavior, SourceConfiguration, LambdaEdgeEventType } from '@aws-cdk/aws-cloudfront';
+import { OriginAccessIdentity, CloudFrontWebDistribution, PriceClass, ViewerProtocolPolicy, SecurityPolicyProtocol, SSLMethod, Behavior, SourceConfiguration } from '@aws-cdk/aws-cloudfront';
 import { HostedZone, RecordTarget, ARecord } from '@aws-cdk/aws-route53';
 import { CloudFrontTarget } from '@aws-cdk/aws-route53-targets';
 import { User, Group, Policy, PolicyStatement, Effect } from '@aws-cdk/aws-iam';
 
-export interface PwaHostingProps {
+export interface StaticHostingProps {
     domainName: string;
     subDomainName: string;
     certificateArn: string;
@@ -26,13 +26,8 @@ export interface PwaHostingProps {
     behaviors?: Array<Behavior>;
 }
 
-export interface EdgeFunctionReference {
-  eventType: LambdaEdgeEventType;
-  arn: string;
-}
-
 export class StaticHosting extends Construct {
-    constructor(scope: Construct, id: string, props: PwaHostingProps) {
+    constructor(scope: Construct, id: string, props: StaticHostingProps) {
         super(scope, id);
 
         const siteName = `${props.subDomainName}.${props.domainName}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@aligent/aws-cdk-static-hosting-stack",
+  "name": "@aligent/cdk-static-hosting",
   "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@aligent/aws-cdk-static-hosting-stack",
+      "name": "@aligent/cdk-static-hosting",
       "version": "0.1.1",
       "license": "GPL-3.0-only",
       "dependencies": {
@@ -52,7 +52,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.111.0.tgz",
       "integrity": "sha512-O1jZ0cZNxqjSc0tknbecEZZYw5VJxFLsruQT8WguUR0cW2+B6ukdyZw6NBZxAMDrXavWDbqiR/1rdchvm5c+QQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/core": "1.111.0",
         "@aws-cdk/cx-api": "1.111.0",
@@ -71,7 +70,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.111.0.tgz",
       "integrity": "sha512-BY0VlS64hLiQuQpXTlpyS9OfrtrkHXXroWpf9SSP3J4b+ixCZbOPcU1E09nwQjEOeb0Bo0vuK4h/OGrWfsslcQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-certificatemanager": "1.111.0",
         "@aws-cdk/aws-cloudwatch": "1.111.0",
@@ -110,7 +108,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.111.0.tgz",
       "integrity": "sha512-C3XMt3MzvyGTIIksu8/13wSTzE4002MN7+GxBajAbzhSmy7djodCX/FsynQBR/Nfibcabxc0vv1HUoT9JkHf2Q==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-autoscaling-common": "1.111.0",
         "@aws-cdk/aws-cloudwatch": "1.111.0",
@@ -133,7 +130,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.111.0.tgz",
       "integrity": "sha512-JFpxEXOq9JVYcmJ5Bk61jP0lqTL06HjnxiI6lauVNr0LGWlHx1C2dOOr+9rBCRvJxfrKuTXoduPv8E4ywE607A==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-iam": "1.111.0",
         "@aws-cdk/core": "1.111.0",
@@ -152,7 +148,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.111.0.tgz",
       "integrity": "sha512-g5XwE+C4wJtBsNvdEG+eeIDlQsrE8dajED2moCgwdM/CRdVCYE35lPNlxdZoRE0kAZfg5km2CKA07sn3PeRY/A==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-iam": "1.111.0",
         "@aws-cdk/aws-lambda": "1.111.0",
@@ -175,7 +170,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.111.0.tgz",
       "integrity": "sha512-JTHRg8womhclxYpI6Q5POIvML2C3bXmBu2hS1UKpe1uStoceR/u9AxI9uEaxlmvoQhK/TU08GIOFihpBlJeD1w==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-iam": "1.111.0",
         "@aws-cdk/aws-lambda": "1.111.0",
@@ -234,7 +228,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.111.0.tgz",
       "integrity": "sha512-VdJrl53JJKpvK3tPJOGW46rq4BkVci1UaR2scJYzrFEvlUpnTk4TRrGWUZQ3h/A6tgJnitfY4JMhvuwLWGKOuQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-iam": "1.111.0",
         "@aws-cdk/core": "1.111.0",
@@ -253,7 +246,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.111.0.tgz",
       "integrity": "sha512-0nu8gi5vmKS7RjrFp7wjq/6x15lKXcYVsypOKXKb8EfSY1lizmJne5xhuh/mn1LtNqNq/x4mLQ14zBGi0dGUmQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-iam": "1.111.0",
         "@aws-cdk/core": "1.111.0",
@@ -272,7 +264,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.111.0.tgz",
       "integrity": "sha512-BunSZn7cCtKvDnpK0+VMxKbGcBK2h8I3UpiZXqVOGn+a+fpHNGcfRLV1r7u7QUXUiKYy1OlO+ip7PK9oWtP8mQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/core": "1.111.0",
         "constructs": "^3.3.69"
@@ -292,7 +283,6 @@
       "bundleDependencies": [
         "punycode"
       ],
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-certificatemanager": "1.111.0",
         "@aws-cdk/aws-iam": "1.111.0",
@@ -318,7 +308,6 @@
       "version": "2.1.1",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -327,7 +316,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.111.0.tgz",
       "integrity": "sha512-fCB4WYPWJj7yAH5Q+0mSJRPE2zIIpCpf+14NhkyPdClrSyPrDuFWPoZDiBXm0ejY0shhmcLDLyt27zzzQ+MbaA==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-cloudwatch": "1.111.0",
         "@aws-cdk/aws-iam": "1.111.0",
@@ -364,7 +352,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.111.0.tgz",
       "integrity": "sha512-4/qrQ25oUxa+ZjrlJf02+PXF01hLvK/HqfgZt1cIdWDif3KU9SddGI0kIsUk8q0TkhlDDWDdo9DYhQj7+mKB9w==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-events": "1.111.0",
         "@aws-cdk/aws-iam": "1.111.0",
@@ -391,7 +378,6 @@
         "brace-expansion",
         "concat-map"
       ],
-      "peer": true,
       "dependencies": {
         "@aws-cdk/assets": "1.111.0",
         "@aws-cdk/aws-ecr": "1.111.0",
@@ -418,14 +404,12 @@
     "node_modules/@aws-cdk/aws-ecr-assets/node_modules/balanced-match": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@aws-cdk/aws-ecr-assets/node_modules/brace-expansion": {
       "version": "1.1.11",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -434,14 +418,12 @@
     "node_modules/@aws-cdk/aws-ecr-assets/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@aws-cdk/aws-ecr-assets/node_modules/minimatch": {
       "version": "3.0.4",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -453,7 +435,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.111.0.tgz",
       "integrity": "sha512-WED0nS/A4t+8Z+v1eat8uoHkN5bOwS5hKVNaQpL6/Wxj0rbs6GBD/NahDPtbxk+o7aoDhGshOyLY6GAJRBasJQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-ec2": "1.111.0",
         "@aws-cdk/aws-kms": "1.111.0",
@@ -478,7 +459,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.111.0.tgz",
       "integrity": "sha512-wbJ+XmSsf0zWDMdCaXinRM9GvVGs7rmhNNApPtw+t/J1wXnF7FqqwHgQ5kSaXpXfkXjY5arOWzR6mn7HuKgQwQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-ec2": "1.111.0",
         "@aws-cdk/core": "1.111.0",
@@ -497,7 +477,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.111.0.tgz",
       "integrity": "sha512-8RF1cd7/WNTuMAW3/PWT5/x2v0D4mb+9TpgMux5ARo4L2jLqoxdTWlztp60p4hiYLQN8zcwdAPaFl8uFMMHdlw==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-certificatemanager": "1.111.0",
         "@aws-cdk/aws-cloudwatch": "1.111.0",
@@ -532,7 +511,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.111.0.tgz",
       "integrity": "sha512-oYQtwyAUQheDF4BL2t6V9uRRd+3aLTMje/Y744JoxELEHPkP1EiEutg3kI0TER/S1BZ/E35wVkj3tR420p3QJg==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-iam": "1.111.0",
         "@aws-cdk/core": "1.111.0",
@@ -551,7 +529,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.111.0.tgz",
       "integrity": "sha512-Q7Bjuo3T3uUSbo25o5JLhhDM7hn8dQ9fA1ewCXucp/6cFIO2fzBzv62+ZeL55cdsDSq3QUoMWCXNwisvl9GbZA==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-ec2": "1.111.0",
         "@aws-cdk/core": "1.111.0",
@@ -590,7 +567,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.111.0.tgz",
       "integrity": "sha512-m5wu7jRXBHsaevjBrBEjOWmXr9JjyAQWE6m2ONeAw+oNhXt3WZkGzjwIdRbJwX4wOqFv6tjcCvjRzoiKYVEscQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-iam": "1.111.0",
         "@aws-cdk/core": "1.111.0",
@@ -611,7 +587,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.111.0.tgz",
       "integrity": "sha512-4qufD9uqn4FjGUJaRwURJ+G9ntV5Z2adkYkSxyzA3/05we6yYGPmiJvyeTlcV/pI9Ti/STopz45rnwXOB9SOHQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-applicationautoscaling": "1.111.0",
         "@aws-cdk/aws-cloudwatch": "1.111.0",
@@ -660,7 +635,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.111.0.tgz",
       "integrity": "sha512-GmVLxVU8axHGL5Yd/HlKz/1ViMNJfl+HC9VO0r132XUcVpSX94ergOJFkdM5oJnjJaLdvzW2ZGtgv0anuAa9mQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-cloudwatch": "1.111.0",
         "@aws-cdk/aws-iam": "1.111.0",
@@ -773,7 +747,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.111.0.tgz",
       "integrity": "sha512-viKjW0TE+k23HpddxHUO6j+rCQBKmUYuIqvyhYD8p8tnsgmwBNKlLexiDghkd24+RmkFQMhQmrQrT4niSJffEw==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/assets": "1.111.0",
         "@aws-cdk/aws-iam": "1.111.0",
@@ -800,7 +773,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.111.0.tgz",
       "integrity": "sha512-rWXo/kggORGiWctX6YsKSO/+D9UicxHh8z1hNeQXRCvdVAeorY5Xx7DpfMCzpgOc28FF1qwqusWwBP36XDNs1Q==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/core": "1.111.0",
         "constructs": "^3.3.69"
@@ -817,7 +789,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.111.0.tgz",
       "integrity": "sha512-EnlG+GmohM8OlZMS1FbAGyc9BHBpMSjxC2gpm6ZmNisFTxpSC66EnkWeXOhD/ZfjqaxiLFEYoKM8IGc6dy2eFg==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-cloudwatch": "1.111.0",
         "@aws-cdk/aws-codestarnotifications": "1.111.0",
@@ -846,7 +817,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.111.0.tgz",
       "integrity": "sha512-OH/1Tu8uGvPvFkqQD/f0hmOqgDjClMZ8IhM6SZ7zvqYKsFjgrHqyorKcGDViCoWWbN/TNKjbW6rcHtas1KIo/A==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-cloudwatch": "1.111.0",
         "@aws-cdk/aws-iam": "1.111.0",
@@ -869,7 +839,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.111.0.tgz",
       "integrity": "sha512-/rBwM0j8n78Ih62nnJ2d86hoChWid6BN0qEKYiK/1RqrWyXWpNAVADW0rK1Ous8L0qC1rHOFTCoxDVuIM6+VdQ==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-iam": "1.111.0",
         "@aws-cdk/aws-kms": "1.111.0",
@@ -907,7 +876,6 @@
         "lru-cache",
         "yallist"
       ],
-      "peer": true,
       "dependencies": {
         "jsonschema": "^1.4.0",
         "semver": "^7.3.5"
@@ -920,7 +888,6 @@
       "version": "1.4.0",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -929,7 +896,6 @@
       "version": "6.0.0",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -941,7 +907,6 @@
       "version": "7.3.5",
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -955,8 +920,7 @@
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
       "version": "4.0.0",
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@aws-cdk/cloudformation-diff": {
       "version": "1.111.0",
@@ -1112,7 +1076,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.111.0.tgz",
       "integrity": "sha512-1RjXUcgKacXQNzjULBkq26OO/WUyX+eKckHtPip2h9fe0nCu3y01zzT6zTt6/GqR0I28T2N3RAV0wzE3Zwy53w==",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/aws-cloudformation": "1.111.0",
         "@aws-cdk/aws-ec2": "1.111.0",
@@ -1191,7 +1154,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.111.0.tgz",
       "integrity": "sha512-xUqNPkg5cEV/df1aSle2cc+yasgyOtFPMXw53PYMTArwfmHMsXb5Lna0lsFddMx4heO+be5XYUrWVijIiPHMIQ==",
-      "peer": true,
       "engines": {
         "node": ">= 10.13.0 <13 || >=13.7.0"
       }
@@ -4197,7 +4159,6 @@
       "version": "3.3.75",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.75.tgz",
       "integrity": "sha512-q10foASSSfDWmS99OQLfnWDXCzqLvoORISAVWPFg0AmIGlBv2ZdDOtXxLqrJARPxVlOldmW2JzWzdRI+4+0/ZA==",
-      "peer": true,
       "engines": {
         "node": ">= 10.17.0"
       }
@@ -9009,91 +8970,152 @@
       "dev": true,
       "requires": {
         "@aws-cdk/cloudformation-diff": "1.111.0",
-        "@aws-cdk/cx-api": "1.111.0"
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/assets": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.111.0.tgz",
       "integrity": "sha512-O1jZ0cZNxqjSc0tknbecEZZYw5VJxFLsruQT8WguUR0cW2+B6ukdyZw6NBZxAMDrXavWDbqiR/1rdchvm5c+QQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-apigateway": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.111.0.tgz",
       "integrity": "sha512-BY0VlS64hLiQuQpXTlpyS9OfrtrkHXXroWpf9SSP3J4b+ixCZbOPcU1E09nwQjEOeb0Bo0vuK4h/OGrWfsslcQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.111.0",
+        "@aws-cdk/aws-cloudwatch": "1.111.0",
+        "@aws-cdk/aws-cognito": "1.111.0",
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-lambda": "1.111.0",
+        "@aws-cdk/aws-logs": "1.111.0",
+        "@aws-cdk/aws-s3": "1.111.0",
+        "@aws-cdk/aws-s3-assets": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-applicationautoscaling": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.111.0.tgz",
       "integrity": "sha512-C3XMt3MzvyGTIIksu8/13wSTzE4002MN7+GxBajAbzhSmy7djodCX/FsynQBR/Nfibcabxc0vv1HUoT9JkHf2Q==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-autoscaling-common": "1.111.0",
+        "@aws-cdk/aws-cloudwatch": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-autoscaling-common": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.111.0.tgz",
       "integrity": "sha512-JFpxEXOq9JVYcmJ5Bk61jP0lqTL06HjnxiI6lauVNr0LGWlHx1C2dOOr+9rBCRvJxfrKuTXoduPv8E4ywE607A==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-certificatemanager": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.111.0.tgz",
       "integrity": "sha512-g5XwE+C4wJtBsNvdEG+eeIDlQsrE8dajED2moCgwdM/CRdVCYE35lPNlxdZoRE0kAZfg5km2CKA07sn3PeRY/A==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-lambda": "1.111.0",
+        "@aws-cdk/aws-route53": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-cloudformation": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.111.0.tgz",
       "integrity": "sha512-JTHRg8womhclxYpI6Q5POIvML2C3bXmBu2hS1UKpe1uStoceR/u9AxI9uEaxlmvoQhK/TU08GIOFihpBlJeD1w==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-lambda": "1.111.0",
+        "@aws-cdk/aws-s3": "1.111.0",
+        "@aws-cdk/aws-sns": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-cloudfront": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.111.0.tgz",
       "integrity": "sha512-wNm1+7XRYfV9NRlJoiOrSDzdEm6Uc0wgEpR8XCIK+1/XLq0XS6CdSQtVoGwCNv78M3Xg6udOCuVV7OgYq7pbaA==",
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.111.0",
+        "@aws-cdk/aws-cloudwatch": "1.111.0",
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/aws-lambda": "1.111.0",
+        "@aws-cdk/aws-s3": "1.111.0",
+        "@aws-cdk/aws-ssm": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-cloudwatch": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.111.0.tgz",
       "integrity": "sha512-VdJrl53JJKpvK3tPJOGW46rq4BkVci1UaR2scJYzrFEvlUpnTk4TRrGWUZQ3h/A6tgJnitfY4JMhvuwLWGKOuQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-codeguruprofiler": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.111.0.tgz",
       "integrity": "sha512-0nu8gi5vmKS7RjrFp7wjq/6x15lKXcYVsypOKXKb8EfSY1lizmJne5xhuh/mn1LtNqNq/x4mLQ14zBGi0dGUmQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-codestarnotifications": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.111.0.tgz",
       "integrity": "sha512-BunSZn7cCtKvDnpK0+VMxKbGcBK2h8I3UpiZXqVOGn+a+fpHNGcfRLV1r7u7QUXUiKYy1OlO+ip7PK9oWtP8mQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-cognito": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.111.0.tgz",
       "integrity": "sha512-k0vjUtlqQ7i1KSq09QDb/D9fhjhdmS18CMT6tINeA6GWJnRxIfYlNbvYr0oDfBptrCDGe/GT4FTikzlDD8ZeRA==",
-      "peer": true,
       "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-lambda": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/custom-resources": "1.111.0",
+        "constructs": "^3.3.69",
         "punycode": "^2.1.1"
       },
       "dependencies": {
         "punycode": {
           "version": "2.1.1",
-          "bundled": true,
-          "peer": true
+          "bundled": true
         }
       }
     },
@@ -9101,34 +9123,54 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.111.0.tgz",
       "integrity": "sha512-fCB4WYPWJj7yAH5Q+0mSJRPE2zIIpCpf+14NhkyPdClrSyPrDuFWPoZDiBXm0ejY0shhmcLDLyt27zzzQ+MbaA==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/aws-logs": "1.111.0",
+        "@aws-cdk/aws-s3": "1.111.0",
+        "@aws-cdk/aws-s3-assets": "1.111.0",
+        "@aws-cdk/aws-ssm": "1.111.0",
+        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "@aws-cdk/region-info": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-ecr": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.111.0.tgz",
       "integrity": "sha512-4/qrQ25oUxa+ZjrlJf02+PXF01hLvK/HqfgZt1cIdWDif3KU9SddGI0kIsUk8q0TkhlDDWDdo9DYhQj7+mKB9w==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-events": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-ecr-assets": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.111.0.tgz",
       "integrity": "sha512-3jIYD4W30p/Fj8Xtpk4+IuXajgpGoGXbgy+uNdF4OBY2/Xk1APTP3HnAAwtt2JsR4oI+dsS1Zi+ZZRhz24Ea3w==",
-      "peer": true,
       "requires": {
+        "@aws-cdk/assets": "1.111.0",
+        "@aws-cdk/aws-ecr": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-s3": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true,
-          "peer": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "peer": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9136,13 +9178,11 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "peer": true
+          "bundled": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "peer": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9153,116 +9193,231 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.111.0.tgz",
       "integrity": "sha512-WED0nS/A4t+8Z+v1eat8uoHkN5bOwS5hKVNaQpL6/Wxj0rbs6GBD/NahDPtbxk+o7aoDhGshOyLY6GAJRBasJQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-elasticloadbalancing": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.111.0.tgz",
       "integrity": "sha512-wbJ+XmSsf0zWDMdCaXinRM9GvVGs7rmhNNApPtw+t/J1wXnF7FqqwHgQ5kSaXpXfkXjY5arOWzR6mn7HuKgQwQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-elasticloadbalancingv2": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.111.0.tgz",
       "integrity": "sha512-8RF1cd7/WNTuMAW3/PWT5/x2v0D4mb+9TpgMux5ARo4L2jLqoxdTWlztp60p4hiYLQN8zcwdAPaFl8uFMMHdlw==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.111.0",
+        "@aws-cdk/aws-cloudwatch": "1.111.0",
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-lambda": "1.111.0",
+        "@aws-cdk/aws-s3": "1.111.0",
+        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "@aws-cdk/region-info": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-events": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.111.0.tgz",
       "integrity": "sha512-oYQtwyAUQheDF4BL2t6V9uRRd+3aLTMje/Y744JoxELEHPkP1EiEutg3kI0TER/S1BZ/E35wVkj3tR420p3QJg==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-globalaccelerator": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.111.0.tgz",
       "integrity": "sha512-Q7Bjuo3T3uUSbo25o5JLhhDM7hn8dQ9fA1ewCXucp/6cFIO2fzBzv62+ZeL55cdsDSq3QUoMWCXNwisvl9GbZA==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/custom-resources": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-iam": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.111.0.tgz",
       "integrity": "sha512-ha0Lv0iudBeuzOlBP5eadoaVf4fASyLDmcBg99f7gHImITaS2T5JqEFY4YRUYjwoJtAUkHTVIcMF2KanWORaIw==",
-      "requires": {}
+      "requires": {
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/region-info": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-kms": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.111.0.tgz",
       "integrity": "sha512-m5wu7jRXBHsaevjBrBEjOWmXr9JjyAQWE6m2ONeAw+oNhXt3WZkGzjwIdRbJwX4wOqFv6tjcCvjRzoiKYVEscQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-lambda": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.111.0.tgz",
       "integrity": "sha512-4qufD9uqn4FjGUJaRwURJ+G9ntV5Z2adkYkSxyzA3/05we6yYGPmiJvyeTlcV/pI9Ti/STopz45rnwXOB9SOHQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.111.0",
+        "@aws-cdk/aws-cloudwatch": "1.111.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.111.0",
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/aws-ecr": "1.111.0",
+        "@aws-cdk/aws-ecr-assets": "1.111.0",
+        "@aws-cdk/aws-efs": "1.111.0",
+        "@aws-cdk/aws-events": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/aws-logs": "1.111.0",
+        "@aws-cdk/aws-s3": "1.111.0",
+        "@aws-cdk/aws-s3-assets": "1.111.0",
+        "@aws-cdk/aws-signer": "1.111.0",
+        "@aws-cdk/aws-sqs": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-logs": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.111.0.tgz",
       "integrity": "sha512-GmVLxVU8axHGL5Yd/HlKz/1ViMNJfl+HC9VO0r132XUcVpSX94ergOJFkdM5oJnjJaLdvzW2ZGtgv0anuAa9mQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/aws-s3-assets": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-route53": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.111.0.tgz",
       "integrity": "sha512-49nrnOtS0B9L2UXvoNvCeOPSHZ8If/SuAOXCTwOoeMf/ZGuTU+POhXA198aJ6JiLPO6Yq6ivJyxYPzjfDayj8g==",
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-logs": "1.111.0",
+        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/custom-resources": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-route53-targets": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.111.0.tgz",
       "integrity": "sha512-TJOHKBgPVnAvb9d9gn2UsZVIdaMWaAWrJ1QOHv64uihDKpSM0VgDSw0d3eo6tH334wUqtN5NVJyQlH2VNMSbHQ==",
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-apigateway": "1.111.0",
+        "@aws-cdk/aws-cloudfront": "1.111.0",
+        "@aws-cdk/aws-cognito": "1.111.0",
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/aws-elasticloadbalancing": "1.111.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.111.0",
+        "@aws-cdk/aws-globalaccelerator": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-route53": "1.111.0",
+        "@aws-cdk/aws-s3": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/region-info": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-s3": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.111.0.tgz",
       "integrity": "sha512-xZiJv/RjN1Cv4dqt9TxNAzw3wxqpPfsV9TQ9EDqzWc9f7ESMUj34+r2DSGHimLIf8WFvy4rFAYXY7akP9v77jA==",
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-events": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-s3-assets": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.111.0.tgz",
       "integrity": "sha512-viKjW0TE+k23HpddxHUO6j+rCQBKmUYuIqvyhYD8p8tnsgmwBNKlLexiDghkd24+RmkFQMhQmrQrT4niSJffEw==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/assets": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/aws-s3": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-signer": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.111.0.tgz",
       "integrity": "sha512-rWXo/kggORGiWctX6YsKSO/+D9UicxHh8z1hNeQXRCvdVAeorY5Xx7DpfMCzpgOc28FF1qwqusWwBP36XDNs1Q==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-sns": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.111.0.tgz",
       "integrity": "sha512-EnlG+GmohM8OlZMS1FbAGyc9BHBpMSjxC2gpm6ZmNisFTxpSC66EnkWeXOhD/ZfjqaxiLFEYoKM8IGc6dy2eFg==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.111.0",
+        "@aws-cdk/aws-codestarnotifications": "1.111.0",
+        "@aws-cdk/aws-events": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/aws-sqs": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-sqs": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.111.0.tgz",
       "integrity": "sha512-OH/1Tu8uGvPvFkqQD/f0hmOqgDjClMZ8IhM6SZ7zvqYKsFjgrHqyorKcGDViCoWWbN/TNKjbW6rcHtas1KIo/A==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/aws-ssm": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.111.0.tgz",
       "integrity": "sha512-/rBwM0j8n78Ih62nnJ2d86hoChWid6BN0qEKYiK/1RqrWyXWpNAVADW0rK1Ous8L0qC1rHOFTCoxDVuIM6+VdQ==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-kms": "1.111.0",
+        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/cfnspec": {
       "version": "1.111.0",
@@ -9277,7 +9432,6 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.111.0.tgz",
       "integrity": "sha512-Ql59HF7PDLQJislHAVhTZE8JHUtb5zikCjHseOuvWh3c5f5jjJ4i7pq9N6wjfamjfC7JGQ7LmRSXP61NIc3aNQ==",
-      "peer": true,
       "requires": {
         "jsonschema": "^1.4.0",
         "semver": "^7.3.5"
@@ -9285,13 +9439,11 @@
       "dependencies": {
         "jsonschema": {
           "version": "1.4.0",
-          "bundled": true,
-          "peer": true
+          "bundled": true
         },
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
-          "peer": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -9299,15 +9451,13 @@
         "semver": {
           "version": "7.3.5",
           "bundled": true,
-          "peer": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true,
-          "peer": true
+          "bundled": true
         }
       }
     },
@@ -9339,7 +9489,11 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.111.0.tgz",
       "integrity": "sha512-ptI43hFZ6yClzyBbCQh1LZgy3b8Z0ekkb6XYCf1BtmqmimvQJOyBc68nfn+NaO2uGDRMor2XhkN9qIRpInSR4w==",
       "requires": {
+        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+        "@aws-cdk/cx-api": "1.111.0",
+        "@aws-cdk/region-info": "1.111.0",
         "@balena/dockerignore": "^1.0.2",
+        "constructs": "^3.3.69",
         "fs-extra": "^9.1.0",
         "ignore": "^5.1.8",
         "minimatch": "^3.0.4"
@@ -9412,14 +9566,23 @@
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.111.0.tgz",
       "integrity": "sha512-1RjXUcgKacXQNzjULBkq26OO/WUyX+eKckHtPip2h9fe0nCu3y01zzT6zTt6/GqR0I28T2N3RAV0wzE3Zwy53w==",
-      "peer": true,
-      "requires": {}
+      "requires": {
+        "@aws-cdk/aws-cloudformation": "1.111.0",
+        "@aws-cdk/aws-ec2": "1.111.0",
+        "@aws-cdk/aws-iam": "1.111.0",
+        "@aws-cdk/aws-lambda": "1.111.0",
+        "@aws-cdk/aws-logs": "1.111.0",
+        "@aws-cdk/aws-sns": "1.111.0",
+        "@aws-cdk/core": "1.111.0",
+        "constructs": "^3.3.69"
+      }
     },
     "@aws-cdk/cx-api": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.111.0.tgz",
       "integrity": "sha512-dGYu+3LapX3Gv4+68kOIQ2igIbAGCqNGcs5+8CFHqilBeRb31FyT5mU5yE3Hkp/+RW0Zy0T+MgCFcu0WXHgJBw==",
       "requires": {
+        "@aws-cdk/cloud-assembly-schema": "1.111.0",
         "semver": "^7.3.5"
       },
       "dependencies": {
@@ -9446,8 +9609,7 @@
     "@aws-cdk/region-info": {
       "version": "1.111.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.111.0.tgz",
-      "integrity": "sha512-xUqNPkg5cEV/df1aSle2cc+yasgyOtFPMXw53PYMTArwfmHMsXb5Lna0lsFddMx4heO+be5XYUrWVijIiPHMIQ==",
-      "peer": true
+      "integrity": "sha512-xUqNPkg5cEV/df1aSle2cc+yasgyOtFPMXw53PYMTArwfmHMsXb5Lna0lsFddMx4heO+be5XYUrWVijIiPHMIQ=="
     },
     "@babel/code-frame": {
       "version": "7.12.13",
@@ -12182,8 +12344,7 @@
     "constructs": {
       "version": "3.3.75",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.75.tgz",
-      "integrity": "sha512-q10foASSSfDWmS99OQLfnWDXCzqLvoORISAVWPFg0AmIGlBv2ZdDOtXxLqrJARPxVlOldmW2JzWzdRI+4+0/ZA==",
-      "peer": true
+      "integrity": "sha512-q10foASSSfDWmS99OQLfnWDXCzqLvoORISAVWPFg0AmIGlBv2ZdDOtXxLqrJARPxVlOldmW2JzWzdRI+4+0/ZA=="
     },
     "convert-source-map": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aligent/aws-cdk-static-hosting",
+  "name": "@aligent/cdk-static-hosting",
   "version": "0.1.1",
   "main": "index.js",
   "license": "GPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aligent/aws-cdk-static-hosting-stack",
+  "name": "@aligent/aws-cdk-static-hosting",
   "version": "0.1.1",
   "main": "index.js",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
This pull request pulls in some internal changes which allow for CloudFront behaviors to be passed in.
This will allow for use with the Aligent prerender.io construct.

I have also taken the opportunity to replace the Stack with a Construct which is the standard way of distributing CDK components. I plan to do this to the other Aligent CDK components.