### PR TITLE
Add option to pass through defaultRootObject config

### DIFF
--- a/lib/static-hosting.ts
+++ b/lib/static-hosting.ts
@@ -25,6 +25,7 @@ export interface StaticHostingProps {
      */
     behaviors?: Array<Behavior>;
     enableErrorConfig: boolean;
+    defaultRootObject?: string
 }
 
 export class StaticHosting extends Construct {
@@ -134,6 +135,7 @@ export class StaticHosting extends Construct {
             sslMethod: SSLMethod.SNI,
           },
           originConfigs,
+          defaultRootObject: props.defaultRootObject,
           priceClass: PriceClass.PRICE_CLASS_ALL,
           viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           loggingConfig: loggingConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aligent/cdk-static-hosting",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aligent/cdk-static-hosting",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@aws-cdk/aws-cloudfront": "1.111.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-static-hosting",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "index.js",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/aligent/aws-cdk-static-hosting-stack#readme",


### PR DESCRIPTION
Provides the option to override the default CloudFront `DefaultRootObject`.